### PR TITLE
Adopt Learn WordPress voice guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ All notable changes to the WordPress Security Style Guide.
 - Added a repo-local generated-artifact smoke validator and a dedicated `Validate Artifacts` workflow for PDF, EPUB, and DOCX outputs.
 - Added a Playwright-based PDF visual smoke test and dedicated workflow with committed baselines for critical page regions.
 - Added a cross-format parity check so a small set of canonical phrases must remain present in the Markdown source and generated PDF, EPUB, and DOCX outputs.
+- Added Learn WordPress's [Writing in the WordPress voice](https://learn.wordpress.org/course/writing-in-the-wordpress-voice/) as an authoritative source for WordPress-specific voice, tone, accessibility, and global-audience guidance, and recommended the course to regular contributors and communications staff.
 
 ### Changed
 - Added glossary coverage for WordPress 7.0 AI-specific terminology, including the Abilities API, AI Client, and connector secret-management context.
+- Revised the voice and inclusive-communication sections to emphasize clear, friendly, positive-neutral writing for a global audience that includes ESL readers, newcomers, and people encountering WordPress through the document for the first time.
 - Refactored the document-generation pipeline into explicit build, validate, and publish jobs so generated artifacts are validated before the bot commit step runs.
 - Updated GitHub Action pins in the PDF visual validation workflow to Node 24-capable major versions to remove runner deprecation warnings.
 - Renamed comparison-table headers from `Do` / `Don't` to `Recommended` / `Avoid` for clearer plain-text guidance across all output formats.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ This guide is intended to be used as a reference when drafting:
 - Educational content for WordPress users.
 - Incident response communications.
 
+Recommended foundational training: [Learn WordPress — Writing in the WordPress voice](https://learn.wordpress.org/course/writing-in-the-wordpress-voice/). Contributors, maintainers, support staff, developer advocates, and communications teams should take the course before making substantial voice-and-tone changes.
+
 ## Contributors
 
 - [Dan Knauss](https://dan.knauss.ca) — (Human) — author, editor, reviewer, researcher
@@ -61,7 +63,7 @@ This guide is intended to be used as a reference when drafting:
 
 ## AI-Assisted Editorial Process
 
-This document and the three related documents in this series are revised with the assistance of frontier LLMs. Multiple models independently review all four documents for factual errors, outdated guidance, and cross-document misalignments, with the WordPress Advanced Administration Handbook as primary authority. A human editor reviews, approves, or rejects every recommended change before it is applied. For the full methodology, see **[AI-Assisted Documentation Processes](https://github.com/dknauss/ai-assisted-docs)**. The machine-readable editorial agent skills and cross-document consistency rules are in the [skills directory](https://github.com/dknauss/ai-assisted-docs/tree/main/wp-docs-skills).
+This document and the three related documents in this series are revised with the assistance of frontier LLMs. Multiple models independently review all four documents for factual errors, outdated guidance, and cross-document misalignments, using WordPress technical documentation as primary authority for product facts and the Learn WordPress course [Writing in the WordPress voice](https://learn.wordpress.org/course/writing-in-the-wordpress-voice/) as primary authority for WordPress-specific voice and accessibility guidance. A human editor reviews, approves, or rejects every recommended change before it is applied. For the full methodology, see **[AI-Assisted Documentation Processes](https://github.com/dknauss/ai-assisted-docs)**. The machine-readable editorial agent skills and cross-document consistency rules are in the [skills directory](https://github.com/dknauss/ai-assisted-docs/tree/main/wp-docs-skills).
 
 ## Project Health
 

--- a/WP-Security-Style-Guide.md
+++ b/WP-Security-Style-Guide.md
@@ -138,7 +138,13 @@ Security writing in the WordPress ecosystem addresses several overlapping audien
 
 -   WordPress community members and contributors, including those involved in core development, plugin review, and support forums.
 
+Because the WordPress community is global, assume mixed levels of experience, cultural context, and English fluency. Many readers will be English as a second language (ESL) speakers, newcomers to WordPress, or people encountering WordPress security concepts for the first time. Write accordingly.
+
+Anything you publish may be someone's first introduction not only to WordPress security, but to WordPress as a project and community. Write to build trust, invite participation, and leave the reader better equipped than you found them.
+
 ### 4.2 Voice
+
+Use the Learn WordPress course [Writing in the WordPress voice](https://learn.wordpress.org/course/writing-in-the-wordpress-voice/) as the WordPress-specific editorial baseline for voice and accessibility. It recommends writing that is clear and friendly, on the positive side of neutral, and relatively jargon-free for a global audience.
 
 Your voice should convey the brand's personality and values. It is:
 
@@ -158,7 +164,7 @@ Tone adapts to context while the voice remains consistent. The default tone for 
 
 -   **Realistic about problems** — acknowledge risks squarely without catastrophizing.
 
--   **Optimistic and Reassuring** — emphasize what can be done and what has been fixed. Reassure the audience that our team is on top of the problem.
+-   **Positive-Neutral** — default to a clear, friendly, even-handed tone. Reassure only when the facts justify it. Do not drift into hype, marketing warmth, or false certainty.
 
 -   **Down-to-earth** — avoid jargon-heavy abstractions. Prefer plain language.
 
@@ -170,12 +176,24 @@ Tone adapts to context while the voice remains consistent. The default tone for 
 > Incident response guidance: calm, clear, directive. Prioritize the most important actions first.
 > Thought leadership: reflective, well-sourced, open to nuance and debate.
 
+### 4.4 WordPress Voice Baseline
+
+Before publishing, check whether the draft reflects the WordPress voice baseline:
+
+-   **Clear and friendly** — direct, welcoming, and easy to follow.
+-   **Positive side of neutral** — steady and constructive without being chirpy, salesy, or evasive.
+-   **Jargon-light by default** — define unavoidable technical terms on first use.
+-   **Global-reader aware** — avoid idioms, sarcasm, and culture-specific shorthand that may not travel well.
+-   **Newcomer-accessible** — assume some readers are still learning WordPress, security, or both.
+-   **Trust-building** — write as if this may be the reader's first experience with WordPress and its community norms.
 
 ## 5. Inclusive Communication
 
 ### 5.1 Bring Outsiders In
 
 Security writing can easily become a closed conversation among experts. Actively work against this. Explain jargon and technical terms the first time you use them. Spell out acronyms on first use. Helping people learn the vocabulary means helping them enter the community and take responsibility for their own security.
+
+Prefer shorter sentences over dense clause-stacking. Avoid sarcasm, insider banter, and idioms that may confuse international readers or make the writing feel exclusionary. Action-oriented language is usually better than blame-oriented language.
 
 ### 5.2 Language Choices
 
@@ -210,6 +228,17 @@ WordPress has its own vocabulary. Use terms consistently and prefer the forms fa
 -   **Multisite** — a WordPress feature enabling multiple sites on one installation. One word, capitalized.
 
 -   **Auto-update** — WordPress's built-in mechanism for applying updates automatically. Hyphenated.
+
+### 5.4 Before You Publish
+
+Before publishing WordPress security content, ask:
+
+-   Would a non-expert WordPress site owner understand the main point and next step?
+-   Did we define unavoidable technical language?
+-   Did we remove unnecessary idioms, sarcasm, and blame?
+-   Does the draft preserve the reader's dignity while still being candid about risk?
+-   Would this read well as a first introduction to WordPress and its community?
+-   Have we recommended the Learn WordPress course *Writing in the WordPress voice* when the audience includes regular contributors, maintainers, or communications staff?
 
 ## 6. Technical Formatting Guidelines
 
@@ -658,6 +687,8 @@ Plugin/Theme vulnerabilities must always be communicated to customers. To ensure
 ## 10. References and Further Reading
 
 **Style and Writing Guides**
+
+-   [Learn WordPress: Writing in the WordPress voice](https://learn.wordpress.org/course/writing-in-the-wordpress-voice/) — the authoritative WordPress-specific source for voice, tone, global audience awareness, and jargon restraint. Recommended for contributors, maintainers, developer advocates, support staff, and anyone who regularly writes about WordPress.
 
 -   [Bishop Fox Cybersecurity Style Guide](https://bishopfox.com/resources/cybersecurity-style-guide) — the comprehensive reference for cybersecurity terminology and formatting conventions. This style guide is directly indebted to it.
 

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -2,15 +2,15 @@
 
 This file is the single source of truth for architectural counts in the WordPress Security Style Guide. Check this file before writing any count in prose, and update it when adding or removing terms, sections, or structural elements.
 
-Last verified: 2026-06-14
+Last verified: 2026-06-16
 
 ## Architectural Facts
 
 | Fact | Value | Verification command | Last changed |
 |---|---:|---|---|
-| Document lines | 701 | `wc -l WP-Security-Style-Guide.md` | 2026-06-14 |
+| Document lines | 732 | `wc -l WP-Security-Style-Guide.md` | 2026-06-16 |
 | Major sections (H2) | 12 | `grep -cE '^## ' WP-Security-Style-Guide.md` | v1.0 |
-| Subsections (H3) | 26 | `grep -cE '^### ' WP-Security-Style-Guide.md` | v1.0 |
+| Subsections (H3) | 28 | `grep -cE '^### ' WP-Security-Style-Guide.md` | 2026-06-16 |
 | Glossary terms | 143 | `grep -cE '^\*\*' WP-Security-Style-Guide.md` | 2026-06-14 |
 | "See also:" cross-references | 59 | `grep -c 'See also:' WP-Security-Style-Guide.md` | 2026-06-14 |
 | Table rows | 28 | `grep -cE '^\| ' WP-Security-Style-Guide.md` | v1.0 |
@@ -25,8 +25,8 @@ Last verified: 2026-06-14
 |---|---|---|
 | 1–2 | Philosophy | Security, vulnerability, trust in open source |
 | 3 | Writing guidelines | 7 subsections on accuracy, framing, attribution |
-| 4 | Audience and voice | 3 subsections on tone calibration |
-| 5 | Inclusive communication | 3 subsections on terminology, accessibility |
+| 4 | Audience and voice | 4 subsections on audiences, tone, and WordPress voice |
+| 5 | Inclusive communication | 4 subsections on terminology, accessibility, and pre-publish checks |
 | 6 | Technical formatting | 5 subsections on code, links, version references |
 | 7 | Vulnerability writing | 7 subsections on disclosure, severity, communication |
 | 8 | Glossary | 143 defined terms with cross-references |


### PR DESCRIPTION
## Summary\n- adopt Learn WordPress's *Writing in the WordPress voice* as the WordPress-specific editorial authority\n- add a WordPress voice baseline and pre-publish checklist to the style guide\n- recommend the course to contributors and communications staff\n\n## Testing\n- python3 .github/scripts/validate-artifacts.py\n