### PR TITLE
Align process notes with WordPress voice baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the WordPress Security Style Guide.
 - Separated Playwright PDF visual validation from the artifact publish path so `generate-docs.yml` can publish after artifact checks while the dedicated visual workflow handles layout regression checks on workflow, packaging, and Pandoc changes.
 - Added glossary coverage for WordPress 7.0 AI-specific terminology, including the Abilities API, AI Client, and connector secret-management context.
 - Revised the voice and inclusive-communication sections to emphasize clear, friendly, positive-neutral writing for a global audience that includes ESL readers, newcomers, and people encountering WordPress through the document for the first time.
+- Updated contributor and AI-authorship process notes so Learn WordPress's *Writing in the WordPress voice* is explicitly the editorial baseline for WordPress-specific voice, tone, and accessibility decisions.
 - Refactored the document-generation pipeline into explicit build, validate, and publish jobs so generated artifacts are validated before the bot commit step runs.
 - Updated GitHub Action pins in the PDF visual validation workflow to Node 24-capable major versions to remove runner deprecation warnings.
 - Renamed comparison-table headers from `Do` / `Don't` to `Recommended` / `Avoid` for clearer plain-text guidance across all output formats.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,11 @@ Read these files first:
 - `docs/current-metrics.md`
 - `SECURITY.md`
 
+Recommended editorial training before making substantial voice-and-tone
+changes:
+
+- [Learn WordPress — Writing in the WordPress voice](https://learn.wordpress.org/course/writing-in-the-wordpress-voice/)
+
 Related repositories in this document series may also need aligned updates:
 
 - `wp-security-benchmark`
@@ -50,6 +55,9 @@ updates.
 - Verify WordPress-specific terminology against primary sources such as
   `developer.wordpress.org`, WordPress core documentation, or WordPress.org
   project pages.
+- For voice, tone, accessibility, and newcomer-friendliness, treat Learn
+  WordPress's *Writing in the WordPress voice* course as the primary
+  WordPress-specific editorial authority.
 - Keep terminology aligned within the document and across the other repos in
   this series.
 - Update `CHANGELOG.md` for user-visible documentation or workflow changes.
@@ -93,17 +101,20 @@ against committed baselines.
 For canonical document changes:
 
 1. Edit `WP-Security-Style-Guide.md`.
-2. Run `bash .github/scripts/verify-metrics.sh docs/current-metrics.md` if the
+2. If the change materially affects voice, tone, contributor guidance, or
+   audience accessibility expectations, verify that it still aligns with Learn
+   WordPress's *Writing in the WordPress voice* guidance.
+3. Run `bash .github/scripts/verify-metrics.sh docs/current-metrics.md` if the
    change affects structural counts, then update `docs/current-metrics.md` as
    needed.
-3. Update `CHANGELOG.md` for any user-visible documentation or workflow change.
-4. Merge to `main`.
-5. Confirm the phased `Generate PDF, Word & EPUB Documents` workflow completes:
+4. Update `CHANGELOG.md` for any user-visible documentation or workflow change.
+5. Merge to `main`.
+6. Confirm the phased `Generate PDF, Word & EPUB Documents` workflow completes:
    it should build the outputs, run artifact and PDF visual validation, and only
    then publish regenerated files back to `main`.
-6. Use the standalone `Validate Artifacts` and `Validate PDF Visuals` workflows
+7. Use the standalone `Validate Artifacts` and `Validate PDF Visuals` workflows
    for direct validator changes or manual rechecks without regenerating docs.
-7. Create a version tag only when enough user-visible changes justify a release.
+8. Create a version tag only when enough user-visible changes justify a release.
    After tagging, confirm the `Create Release` workflow publishes the generated
    artifacts for that tag.
 
@@ -142,6 +153,8 @@ Pull requests should:
 
 - describe what changed and why
 - mention any source verification performed
+- mention when Learn WordPress's *Writing in the WordPress voice* informed the
+  editorial decision
 - note whether metrics, changelog entries, or generated artifacts changed
 - call out any cross-document follow-up needed in the benchmark, hardening
   guide, or runbook repos

--- a/docs/ai-authorship.md
+++ b/docs/ai-authorship.md
@@ -4,10 +4,19 @@ This repository contains AI-assisted WordPress security editorial guidance. Port
 
 AI assistance is used as an editorial and implementation aid, not as an authority. Human maintainers remain responsible for deciding what belongs in the repository, reviewing changes before publication, and correcting errors.
 
+For WordPress-specific voice, tone, accessibility, and newcomer-friendliness,
+the editorial baseline is the Learn WordPress course
+[*Writing in the WordPress voice*](https://learn.wordpress.org/course/writing-in-the-wordpress-voice/).
+For product facts, version details, command behavior, and security claims, use
+WordPress technical documentation and other primary technical sources.
+
 ## Review expectations
 
 - Treat generated text and code as draft material until reviewed by a human maintainer.
 - Verify volatile facts, API names, version numbers, security claims, and command behavior against primary sources or local tests.
+- For editorial revisions, distinguish between technical authority and voice
+  authority: use Learn WordPress for WordPress voice expectations and primary
+  technical sources for factual claims.
 - Prefer small, reviewable changes with clear commit messages and linked source material where appropriate.
 - Do not publish security vulnerability details, exploit steps, or proof-of-concept material from AI output without following the repository security policy.
 


### PR DESCRIPTION
## Summary\n- update CONTRIBUTING.md to treat Learn WordPress's *Writing in the WordPress voice* as the primary WordPress-specific editorial authority\n- update AI authorship disclosure to distinguish voice authority from technical authority\n- record the process-note change in the changelog\n\n## Testing\n- python3 .github/scripts/validate-artifacts.py\n